### PR TITLE
Log the actual address the listener is bound to.

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,6 @@ func Run(args []string) {
 	http.Handle("/metrics", prometheus.Handler())
 
 	addr := fmt.Sprintf(":%d", port)
-	log.Print("Listening 127.0.0.1", addr)
+	log.Print("Listening 0.0.0.0", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
 }


### PR DESCRIPTION
Fortunately, `http.ListenAndServe` doesn't bind to 127.0.0.1 unless you explicitly request that.