### PR TITLE
Handle requests to /

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,9 @@ func Run(args []string) {
 	prometheus.MustRegister(exporter)
 
 	http.Handle("/metrics", prometheus.Handler())
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(fmt.Sprintf("%s/%s\n", ver, rev)))
+	})
 
 	addr := fmt.Sprintf(":%d", port)
 	log.Print("Listening 0.0.0.0", addr)

--- a/main.go
+++ b/main.go
@@ -65,7 +65,14 @@ func Run(args []string) {
 
 	http.Handle("/metrics", prometheus.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(fmt.Sprintf("%s/%s\n", ver, rev)))
+		w.Write([]byte(`
+<html>
+<body>
+<h3>Resque Exporter v` + ver + `/` + rev + `</h3>
+<p><a href='/metrics'>Metrics</a></p>
+</body>
+</html>
+						`))
 	})
 
 	addr := fmt.Sprintf(":%d", port)


### PR DESCRIPTION
This lets us do health checks against the exporter without having to
collect all the metrics.

For now, just print the version.