### PR TITLE
Add support for monitoring multiple instances/dbs

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,16 +8,16 @@ import (
 )
 
 type Config struct {
-	GuardIntervalMillis int64        `yaml:"guard_interval_millis"`
-	ResqueNamespace     string       `yaml:"resque_namespace"`
-	Redis               *RedisConfig `yaml:"redis"`
+	GuardIntervalMillis int64          `yaml:"guard_interval_millis"`
+	ResqueConfigs       []ResqueConfig `yaml:"resque"`
 }
 
-type RedisConfig struct {
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
-	Password string `yaml:"password"`
-	DB       int64  `yaml:"db"`
+type ResqueConfig struct {
+	Host      string `yaml:"host"`
+	Port      int    `yaml:"port"`
+	Password  string `yaml:"password"`
+	DB        int64  `yaml:"db"`
+	Namespace string `yaml:"namespace"`
 }
 
 func loadConfig(configPath string) (*Config, error) {

--- a/exporter.go
+++ b/exporter.go
@@ -16,13 +16,13 @@ type exporter struct {
 	config         *Config
 	mut            sync.Mutex
 	scrapeFailures prometheus.Counter
-	processed      prometheus.Gauge
-	failedQueue    prometheus.Gauge
-	failedTotal    prometheus.Gauge
+	processed      *prometheus.GaugeVec
+	failedQueue    *prometheus.GaugeVec
+	failedTotal    *prometheus.GaugeVec
 	queueStatus    *prometheus.GaugeVec
-	totalWorkers   prometheus.Gauge
-	activeWorkers  prometheus.Gauge
-	idleWorkers    prometheus.Gauge
+	totalWorkers   *prometheus.GaugeVec
+	activeWorkers  *prometheus.GaugeVec
+	idleWorkers    *prometheus.GaugeVec
 	timer          *time.Timer
 }
 
@@ -35,43 +35,63 @@ func newExporter(config *Config) (*exporter, error) {
 				Name:      "jobs_in_queue",
 				Help:      "Number of remained jobs in queue",
 			},
-			[]string{"queue_name"},
+			[]string{"host", "db", "namespace", "queue_name"},
 		),
-		processed: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "processed",
-			Help:      "Number of processed jobs",
-		}),
-		failedQueue: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "failed_queue_count",
-			Help:      "Number of jobs in the failed queue",
-		}),
-		failedTotal: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "failed",
-			Help:      "Number of failed jobs",
-		}),
-		scrapeFailures: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "exporter_scrape_failures_total",
-			Help:      "Number of errors while scraping resque.",
-		}),
-		totalWorkers: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "total_workers",
-			Help:      "Number of workers",
-		}),
-		activeWorkers: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "active_workers",
-			Help:      "Number of active workers",
-		}),
-		idleWorkers: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "idle_workers",
-			Help:      "Number of idle workers",
-		}),
+		processed: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "processed",
+				Help:      "Number of processed jobs",
+			},
+			[]string{"host", "db", "namespace"},
+		),
+		failedQueue: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "failed_queue_count",
+				Help:      "Number of jobs in the failed queue",
+			},
+			[]string{"host", "db", "namespace"},
+		),
+		failedTotal: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "failed",
+				Help:      "Number of failed jobs",
+			},
+			[]string{"host", "db", "namespace"},
+		),
+		scrapeFailures: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "exporter_scrape_failures_total",
+				Help:      "Number of errors while scraping resque.",
+			},
+		),
+		totalWorkers: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "total_workers",
+				Help:      "Number of workers",
+			},
+			[]string{"host", "db", "namespace"},
+		),
+		activeWorkers: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "active_workers",
+				Help:      "Number of active workers",
+			},
+			[]string{"host", "db", "namespace"},
+		),
+		idleWorkers: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "idle_workers",
+				Help:      "Number of idle workers",
+			},
+			[]string{"host", "db", "namespace"},
+		),
 	}
 
 	return e, nil
@@ -98,9 +118,7 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	if err := e.collect(ch); err != nil {
-		e.incrementFailures(ch)
-	}
+	e.collect(ch)
 
 	e.timer = time.AfterFunc(time.Duration(e.config.GuardIntervalMillis)*time.Millisecond, func() {
 		// reset timer
@@ -110,73 +128,88 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 	})
 }
 
-func (e *exporter) collect(ch chan<- prometheus.Metric) error {
-	resqueNamespace := e.config.ResqueNamespace
+func (e *exporter) collect(ch chan<- prometheus.Metric) {
+	var wg sync.WaitGroup
+	for i := range e.config.ResqueConfigs {
+		resqueConf := e.config.ResqueConfigs[i]
+		labels := []string{resqueConf.Host, strconv.FormatInt(resqueConf.DB, 10), resqueConf.Namespace}
 
-	redisConfig := e.config.Redis
-	redisOpt := &redis.Options{
-		Addr:     fmt.Sprintf("%s:%d", redisConfig.Host, redisConfig.Port),
-		Password: redisConfig.Password,
-		DB:       redisConfig.DB,
-	}
-	redis := redis.NewClient(redisOpt)
-	defer redis.Close()
+		resqueNamespace := resqueConf.Namespace
 
-	failed, err := redis.LLen(fmt.Sprintf("%s:failed", resqueNamespace)).Result()
-	if err != nil {
-		return err
-	}
-	e.failedQueue.Set(float64(failed))
-
-	queues, err := redis.SMembers(fmt.Sprintf("%s:queues", resqueNamespace)).Result()
-	if err != nil {
-		return err
-	}
-
-	for _, q := range queues {
-		n, err := redis.LLen(fmt.Sprintf("%s:queue:%s", resqueNamespace, q)).Result()
-		if err != nil {
-			return err
+		redisOpt := &redis.Options{
+			Addr:     fmt.Sprintf("%s:%d", resqueConf.Host, resqueConf.Port),
+			Password: resqueConf.Password,
+			DB:       resqueConf.DB,
 		}
-		e.queueStatus.WithLabelValues(q).Set(float64(n))
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			redis := redis.NewClient(redisOpt)
+			defer redis.Close()
+
+			failed, err := redis.LLen(fmt.Sprintf("%s:failed", resqueNamespace)).Result()
+			if err != nil {
+				e.incrementFailures(ch)
+				return
+			}
+			e.failedQueue.WithLabelValues(labels...).Set(float64(failed))
+
+			queues, err := redis.SMembers(fmt.Sprintf("%s:queues", resqueNamespace)).Result()
+			if err != nil {
+				e.incrementFailures(ch)
+				return
+			}
+
+			for _, q := range queues {
+				n, err := redis.LLen(fmt.Sprintf("%s:queue:%s", resqueNamespace, q)).Result()
+				if err != nil {
+					e.incrementFailures(ch)
+					return
+				}
+				e.queueStatus.WithLabelValues(append(labels, q)...).Set(float64(n))
+			}
+
+			processed, err := redis.Get(fmt.Sprintf("%s:stat:processed", resqueNamespace)).Result()
+			if err != nil {
+				e.incrementFailures(ch)
+				return
+			}
+			processedCnt, _ := strconv.ParseFloat(processed, 64)
+			e.processed.WithLabelValues(labels...).Set(processedCnt)
+
+			failedtotal, err := redis.Get(fmt.Sprintf("%s:stat:failed", resqueNamespace)).Result()
+			if err != nil {
+				e.incrementFailures(ch)
+				return
+			}
+			failedCnt, _ := strconv.ParseFloat(failedtotal, 64)
+			e.failedTotal.WithLabelValues(labels...).Set(failedCnt)
+
+			workers, err := redis.SMembers(fmt.Sprintf("%s:workers", resqueNamespace)).Result()
+			if err != nil {
+				e.incrementFailures(ch)
+				return
+			}
+			e.totalWorkers.WithLabelValues(labels...).Set(float64(len(workers)))
+
+			activeWorkers := 0
+			idleWorkers := 0
+			for _, w := range workers {
+				_, err := redis.Get(fmt.Sprintf("%s:worker:%s", resqueNamespace, w)).Result()
+				if err == nil {
+					activeWorkers++
+				} else {
+					idleWorkers++
+				}
+			}
+			e.activeWorkers.WithLabelValues(labels...).Set(float64(activeWorkers))
+			e.idleWorkers.WithLabelValues(labels...).Set(float64(idleWorkers))
+		}()
 	}
 
-	processed, err := redis.Get(fmt.Sprintf("%s:stat:processed", resqueNamespace)).Result()
-	if err != nil {
-		return err
-	}
-	processedCnt, _ := strconv.ParseFloat(processed, 64)
-	e.processed.Set(processedCnt)
-
-	failedtotal, err := redis.Get(fmt.Sprintf("%s:stat:failed", resqueNamespace)).Result()
-	if err != nil {
-		return err
-	}
-	failedCnt, _ := strconv.ParseFloat(failedtotal, 64)
-	e.failedTotal.Set(failedCnt)
-
-	workers, err := redis.SMembers(fmt.Sprintf("%s:workers", resqueNamespace)).Result()
-	if err != nil {
-		return err
-	}
-	e.totalWorkers.Set(float64(len(workers)))
-
-	activeWorkers := 0
-	idleWorkers := 0
-	for _, w := range workers {
-		_, err := redis.Get(fmt.Sprintf("%s:worker:%s", resqueNamespace, w)).Result()
-		if err == nil {
-			activeWorkers++
-		} else {
-			idleWorkers++
-		}
-	}
-	e.activeWorkers.Set(float64(activeWorkers))
-	e.idleWorkers.Set(float64(idleWorkers))
-
+	wg.Wait()
 	e.notifyToCollect(ch)
-
-	return nil
 }
 
 func (e *exporter) incrementFailures(ch chan<- prometheus.Metric) {

--- a/sample_config.yml
+++ b/sample_config.yml
@@ -1,9 +1,8 @@
 ---
-resque_namespace: your_namespace (e.g. resque)
 guard_interval_millis: 0
-redis:
+resque:
+  - namespace: your_namespace (e.g. resque)
     host: 127.0.0.1
     port: 6379
     password: pswd
     db: 0
-


### PR DESCRIPTION
In our production environment we need to monitor multiple DBs and namespaces (sometimes on the same redis host/cluster).
This PR adds support for specifying multiple hosts and DBs in the configuration and adds extra labels for `host`, `db`, and `namespace` to the metrics.