### PR TITLE
Log errors when collect fails

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -99,6 +99,8 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	if err := e.collect(ch); err != nil {
+		log.Printf("collect failed: %s\n", err)
+
 		e.incrementFailures(ch)
 	}
 


### PR DESCRIPTION
Makes it easier to find out why things are not working.